### PR TITLE
Fix POST requests and fix the tentative json.loads (bug #7)

### DIFF
--- a/syncthing/__init__.py
+++ b/syncthing/__init__.py
@@ -221,7 +221,7 @@ class Interface(object):
             resp = requests.request(
                 verb,
                 url,
-                data=data,
+                data=json.dumps(data),
                 params=params,
                 timeout=self.timeout,
                 verify=self.verify,
@@ -252,7 +252,7 @@ class Interface(object):
             if 'json' in resp.headers.get('Content-Type', 'text/plain').lower():
                 return resp.json()
             else:
-                c = resp.content
+                c = resp.content.decode("utf-8")
                 if c.startswith('{') and c.endswith('}'):
                     return json.loads(c)
                 return c


### PR DESCRIPTION
- `requests.request` requires `data` to be in a `bytes` format (json.dumps).
- `resp.content` is a `str` in Python3: either cast it to `bytes` (what I did)
  or dereference the string: c.startwith('{') -> c[0] == u'{'