### PR TITLE
Don't call resp.text

### DIFF
--- a/syncthing/__init__.py
+++ b/syncthing/__init__.py
@@ -431,7 +431,7 @@ class System(BaseAPI):
                 dict: with keys ``success`` and ``error``.
         """
         resp = self.post('pause', params={'device': device}, return_response=True)
-        error = resp.text()
+        error = resp.text
         if not error:
             error = None
         return {'success': resp.status_code == requests.codes.ok,
@@ -491,7 +491,7 @@ class System(BaseAPI):
                 dict: with keys ``success`` and ``error``.
         """
         resp = self.post('resume', params={'device': device}, return_response=True)
-        error = resp.text()
+        error = resp.text
         if not error:
             error = None
         return {'success': resp.status_code == requests.codes.ok,


### PR DESCRIPTION
Currently, using `system.pause()` and `system.resume()` causes a TypeError, since `resp.text` is either `str` (python3) or `unicode` (python2). Not trying to call `resp.text` avoids this.