### PR TITLE
Use dateutil to replace parse_datetime

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+python-dateutil==2.6.1
 requests==2.9.0
 six==1.10.0
 wheel==0.24.0


### PR DESCRIPTION
Times like `2017-11-09T14:59:48.48534+01:00` would break the original function. Instead of trying to fix it I opted to replace it by a widely used library.