### PR TITLE
Fix typo in code

### DIFF
--- a/syncthing/__init__.py
+++ b/syncthing/__init__.py
@@ -247,7 +247,7 @@ class BaseAPI(object):
                 else:
                     return content
 
-            if isinstance(json_data, dict) and j.get('error'):
+            if isinstance(json_data, dict) and json_data.get('error'):
                 api_err = json_data.get('error')
                 raise SyncthingError(api_err)
             return json_data


### PR DESCRIPTION
 Otherwise I get the following error:

File "/usr/lib/python3.6/site-packages/syncthing/__init__.py", line 279, in config                                        
    return self.get('config')                                                                                               
  File "/usr/lib/python3.6/site-packages/syncthing/__init__.py", line 180, in get                                           
    return_response, raw_exceptions)                                                                                        
  File "/usr/lib/python3.6/site-packages/syncthing/__init__.py", line 250, in _request
    if isinstance(json_data, dict) and j.get('error'):                     
NameError: name 'j' is not defined