### PR TITLE
v2.3.0 targetting v0.14.44

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ python-syncthing
 ================
 
 [![pypi](https://img.shields.io/pypi/v/syncthing.svg?style=flat)](https://pypi.python.org/pypi/syncthing)
-[![Syncthing](https://img.shields.io/badge/syncthing-0.14.36-blue.svg?style=flat)](https://syncthing.net)
+[![Syncthing](https://img.shields.io/badge/syncthing-0.14.44-blue.svg?style=flat)](https://syncthing.net)
 [![Documentation Status](https://readthedocs.org/projects/python-syncthing/badge/?version=latest)](http://python-syncthing.readthedocs.io/en/latest/?badge=latest)
 [![MIT License](https://img.shields.io/github/license/blakev/python-syncthing.svg?style=flat)](https://github.com/blakev/python-syncthing/blob/master/LICENSE)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-python-dateutil==2.6.1
-requests==2.18.4
-sphinxcontrib-napoleon
-sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,15 @@ from setuptools import setup
 
 setup(
     name = 'syncthing',
-    version = '2.2.0',
+    version = '2.3.0',
     author = 'Blake VandeMerwe',
     author_email = 'blakev@null.net',
-    description = 'Python bindings to the Syncthing REST interface, targeting v0.14.36',
+    description = 'Python bindings to the Syncthing REST interface, targeting v0.14.44',
     url = 'https://github.com/blakev/python-syncthing',
     license = 'The MIT License',
     install_requires = [
-        'requests==2.18.4',
+        'python-dateutil==2.6.1',
+        'requests==2.18.4'
     ],
     extras_require = {
         'dev': [

--- a/syncthing/meta.py
+++ b/syncthing/meta.py
@@ -19,5 +19,5 @@
 __title__ = 'python-syncthing'
 __author__ = 'Blake VandeMerwe'
 __authoremail__ = 'blakev@null.net'
-__version__ = '2.2.0'
+__version__ = '2.3.0'
 

--- a/tests/test_parse_datetime.py
+++ b/tests/test_parse_datetime.py
@@ -1,0 +1,44 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# >>
+#     Copyright (c) 2016-2017, Blake VandeMerwe
+#
+#       Permission is hereby granted, free of charge, to any person obtaining
+#       a copy of this software and associated documentation files
+#       (the "Software"), to deal in the Software without restriction,
+#       including without limitation the rights to use, copy, modify, merge,
+#       publish, distribute, sublicense, and/or sell copies of the Software,
+#       and to permit persons to whom the Software is furnished to do so, subject
+#       to the following conditions: The above copyright notice and this permission
+#       notice shall be included in all copies or substantial portions
+#       of the Software.
+#
+#     python-syncthing, 2016
+# <<
+
+import unittest
+from datetime import datetime
+
+from syncthing import SyncthingError, parse_datetime
+
+
+class TestParseDatetime(unittest.TestCase):
+    def test_empties(self):
+        assert parse_datetime(None) is None
+        assert parse_datetime('') is None
+        assert parse_datetime(0) is None
+
+    def test_raises(self):
+        self.assertRaises(SyncthingError, parse_datetime, 'abc')
+        self.assertRaises(SyncthingError, parse_datetime, [1])
+
+    def test_old_docstring_tests(self):
+        tests = [
+            ('2016-06-06T19:41:43.039284753+02:00', datetime(2016, 6, 6, 21, 41, 43, 39284)),
+            ('2016-06-06T19:41:43.039284753+02:00', datetime(2016, 6, 6, 21, 41, 43, 39284)),
+            ('2016-06-06T19:41:43.039284753-02:00', datetime(2016, 6, 6, 17, 41, 43, 39284)),
+            ('2016-06-06T19:41:43.039284',          datetime(2016, 6, 6, 17, 41, 43, 39284)),
+            ('2016-06-06T19:41:43.039284000-02:00', datetime(2016, 6, 6, 19, 41, 43, 39284))
+        ]
+        for a, b in tests:
+            assert parse_datetime(a).toordinal() == b.toordinal()

--- a/tests/test_scan_folder.py
+++ b/tests/test_scan_folder.py
@@ -1,7 +1,19 @@
-#!/usr/bin/env python
-# ~*~ coding: utf-8 ~*~
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
 # >>
-#   blake, python-syncthing
+#     Copyright (c) 2016-2017, Blake VandeMerwe
+#
+#       Permission is hereby granted, free of charge, to any person obtaining
+#       a copy of this software and associated documentation files
+#       (the "Software"), to deal in the Software without restriction,
+#       including without limitation the rights to use, copy, modify, merge,
+#       publish, distribute, sublicense, and/or sell copies of the Software,
+#       and to permit persons to whom the Software is furnished to do so, subject
+#       to the following conditions: The above copyright notice and this permission
+#       notice shall be included in all copies or substantial portions
+#       of the Software.
+#
+#     python-syncthing, 2016
 # <<
 
 import os
@@ -36,7 +48,8 @@ class TestScanFolder(unittest.TestCase):
         assert s.stats.folder()[use]['lastScan'] > last_scan
 
     def test_folder_scan_sub(self):
-        last_scan = s.stats.folder()['default']['lastScan']
-        ret = s.database.scan('default', 'docs')
+        folder = '2vw2z-xwpvk'
+        last_scan = s.stats.folder()[folder]['lastScan']
+        ret = s.database.scan(folder, 'docs')
         assert isinstance(ret, string_types)
-        assert s.stats.folder()['default']['lastScan'] > last_scan
+        assert s.stats.folder()[folder]['lastScan'] > last_scan

--- a/tests/test_syncthing.py
+++ b/tests/test_syncthing.py
@@ -1,9 +1,20 @@
-#!/usr/bin/env python
-# ~*~ coding: utf-8 ~*~
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
 # >>
-#   blake, python-syncthing
+#     Copyright (c) 2016-2017, Blake VandeMerwe
+#
+#       Permission is hereby granted, free of charge, to any person obtaining
+#       a copy of this software and associated documentation files
+#       (the "Software"), to deal in the Software without restriction,
+#       including without limitation the rights to use, copy, modify, merge,
+#       publish, distribute, sublicense, and/or sell copies of the Software,
+#       and to permit persons to whom the Software is furnished to do so, subject
+#       to the following conditions: The above copyright notice and this permission
+#       notice shall be included in all copies or substantial portions
+#       of the Software.
+#
+#     python-syncthing, 2016
 # <<
-
 from __future__ import unicode_literals
 
 import os


### PR DESCRIPTION
Fix `parse_datetime` to restore original functionality in error cases
Fix unittests and add licensing information
Add the `/rest/system/browse` endpoint
Add the concept of `reraise` for masking native exceptions
Add unittests to ensure compatibility.