### PR TITLE
Add API key to usage example as it is a required parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,21 @@ $ pip install syncthing
 ```python
 from syncthing import Syncthing
 
-s = Syncthing()
+API_KEY = "..."
+
+s = Syncthing(API_KEY)
 
 # name spaced by API endpoints
 s.system.connections()
 
-# suports GET/POST semantics
+# supports GET/POST semantics
 sync_errors = s.system.errors()
 s.system.clear()
 
 if sync_errors:
     for e in sync_errors:
         print(e)
-        
+
 # supports event long-polling
 event_stream = s.events(limit=10)
 for event in event_stream:


### PR DESCRIPTION
To avoid annoyance when copy-pasting example to try out this lib, adding the API key. This way it won't blow up with a `KeyError` to start with.