### PR TITLE
Retry long polling on any timeout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ setup(
     url = 'https://github.com/blakev/python-syncthing',
     license = 'The MIT License',
     install_requires = [
-        'python-dateutil==2.6.1',
-        'requests==2.20.0'
+        'python-dateutil==2.8.1',
+        'requests==2.24.0'
     ],
     extras_require = {
         'dev': [
@@ -41,6 +41,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: System :: Archiving :: Mirroring'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name = 'syncthing',
-    version = '2.3.1',
+    version = '2.4.0',
     author = 'Blake VandeMerwe',
     author_email = 'blakev@null.net',
     description = 'Python bindings to the Syncthing REST interface, targeting v0.14.44',

--- a/syncthing/__init__.py
+++ b/syncthing/__init__.py
@@ -149,6 +149,7 @@ class BaseAPI(object):
         self.port = port
         self.ssl_cert_file = ssl_cert_file
         self.timeout = timeout
+        self.verify = True if ssl_cert_file or is_https else False
         self._headers = {
             'X-API-Key': api_key
         }

--- a/syncthing/__init__.py
+++ b/syncthing/__init__.py
@@ -26,7 +26,7 @@ from collections import namedtuple
 
 import requests
 from dateutil.parser import parse as dateutil_parser
-from requests.exceptions import ConnectionError, ConnectTimeout
+from requests.exceptions import ConnectionError, Timeout
 
 PY2 = sys.version_info[0] < 3
 
@@ -855,7 +855,7 @@ class Events(BaseAPI):
 
             try:
                 data = self.get(using_url, params=params, raw_exceptions=True)
-            except (ConnectTimeout, ConnectionError) as e:
+            except (ConnectionError, Timeout) as e:
                 # swallow timeout errors for long polling
                 data = None
             except Exception as e:


### PR DESCRIPTION
Other changes:
- Bump deps, declare 3.8 support
- Always verify requests to avoid warnings when syncthing server uses valid SSL certificate
- Bump version to 2.4

If everything is ok, please, draft a new release, I'm about to use this package to develop a syncthing integration for https://github.com/home-assistant/core, and it would be awesome if the changes would be available on pypi asap