### PR TITLE
Stop supresssing ConnectionError's in the events generator

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name = 'syncthing',
-    version = '2.4.0',
+    version = '2.4.1',
     author = 'Blake VandeMerwe',
     author_email = 'blakev@null.net',
     description = 'Python bindings to the Syncthing REST interface, targeting v0.14.44',

--- a/syncthing/__init__.py
+++ b/syncthing/__init__.py
@@ -26,7 +26,7 @@ from collections import namedtuple
 
 import requests
 from dateutil.parser import parse as dateutil_parser
-from requests.exceptions import ConnectionError, Timeout
+from requests.exceptions import Timeout
 
 PY2 = sys.version_info[0] < 3
 
@@ -120,7 +120,6 @@ def parse_datetime(s, **kwargs):
     try:
         ret = dateutil_parser(s, **kwargs)
     except (OverflowError, TypeError, ValueError) as e:
-        logger.exception(e, exc_info=True)
         reraise('datetime parsing error from %s' % s, e)
     return ret
 
@@ -206,7 +205,6 @@ class BaseAPI(object):
         except requests.RequestException as e:
             if raw_exceptions:
                 raise e
-            logger.exception(e)
             reraise('http request error', e)
 
         else:
@@ -856,7 +854,7 @@ class Events(BaseAPI):
 
             try:
                 data = self.get(using_url, params=params, raw_exceptions=True)
-            except (ConnectionError, Timeout) as e:
+            except Timeout as e:
                 # swallow timeout errors for long polling
                 data = None
             except Exception as e:


### PR DESCRIPTION
Hello again ;)

After some experiments with the HASS integration I found out that `ConnectionError`'s must not be swallowed, because in case of missing network connection or a syncthing server being down the generator tries to reconnect in an infinite loop consuming lots of CPU.

Also, I found out that the library produces a lot of noise in logs, so I disabled some logging, the errors are reraised anyway

Thank you!