### PR TITLE
Update last seen id after yielding the whole batch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name = 'syncthing',
-    version = '2.4.1',
+    version = '2.4.2',
     author = 'Blake VandeMerwe',
     author_email = 'blakev@null.net',
     description = 'Python bindings to the Syncthing REST interface, targeting v0.14.44',

--- a/syncthing/__init__.py
+++ b/syncthing/__init__.py
@@ -793,6 +793,15 @@ class Events(BaseAPI):
         """
         return self._count
 
+    @property
+    def last_seen_id(self):
+        """ The id of the last seen event.
+
+            Returns:
+                int
+        """
+        return self._last_seen_id
+
     def disk_events(self):
         """ Blocking generator of disk related events. Each event is
         represented as a ``dict`` with metadata.
@@ -861,12 +870,12 @@ class Events(BaseAPI):
                 reraise('', e)
 
             if data:
-                # update our last_seen_id to move our event counter forward
-                self._last_seen_id = data[-1]['id']
                 for event in data:
                     # handle potentially multiple events returned in a list
                     self._count += 1
                     yield event
+                # update our last_seen_id to move our event counter forward
+                self._last_seen_id = data[-1]['id']
 
     def __iter__(self):
         """ Helper interface for :obj:`._events` """

--- a/syncthing/__init__.py
+++ b/syncthing/__init__.py
@@ -27,6 +27,7 @@ from collections import namedtuple
 import requests
 from dateutil.parser import parse as dateutil_parser
 from requests.exceptions import Timeout
+from urllib3.exceptions import TimeoutError
 
 PY2 = sys.version_info[0] < 3
 
@@ -863,7 +864,7 @@ class Events(BaseAPI):
 
             try:
                 data = self.get(using_url, params=params, raw_exceptions=True)
-            except Timeout as e:
+            except (Timeout, TimeoutError) as e:
                 # swallow timeout errors for long polling
                 data = None
             except Exception as e:

--- a/syncthing/meta.py
+++ b/syncthing/meta.py
@@ -19,5 +19,5 @@
 __title__ = 'python-syncthing'
 __author__ = 'Blake VandeMerwe'
 __authoremail__ = 'blakev@null.net'
-__version__ = '2.3.1'
+__version__ = '2.4.2'
 


### PR DESCRIPTION
Hello!

After further investigation I found out that it's very handy to know if an event comes from the very first batch. Such events must be ignored because they are historical data, clients usually need only newer events. 

In order to achieve it I moved the assignment of the `_last_seen_id` after yielding the whole batch and exposed it as a property. Now it's possible to use the same approach as the official gui does: https://github.com/syncthing/syncthing/blob/main/gui/default/syncthing/core/eventService.js#L22

Thank you!

UPD: Catch one more timeout exception